### PR TITLE
Add Cylestio trace interceptor for event monitoring

### DIFF
--- a/examples/configs/anthropic-basic.yaml
+++ b/examples/configs/anthropic-basic.yaml
@@ -24,17 +24,13 @@ interceptors:
       show_llm_calls: true
       show_tools: true
 
-  # Message logger for LLM conversations
-  - type: "message_logger"
+  # Cylestio trace interceptor
+  - type: "cylestio_trace"
     enabled: true
     config:
-      directory: "./message_logs"
-      filename: "message_log.jsonl"
-      include_system_prompts: true
-      include_metadata: true
-      buffer_size: 1  # Buffer 1 message before writing to disk (for testing)
-
-      
+      api_url: "http://localhost:8000"
+      access_key: "${CYLESTIO_ACCESS_KEY}"  # Set this environment variable
+      timeout: 10
 
 logging:
   level: "INFO"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ typer==0.9.0
 uvicorn==0.27.0
 python-multipart==0.0.6
 python-dotenv==1.0.0
+descope==1.7.7
 
 # Development dependencies
 pytest==7.4.4

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -62,6 +62,24 @@ class SessionConfig(BaseModel):
     
 
 
+class CylestioConfig(BaseModel):
+    """Cylestio tracing configuration."""
+    
+    enabled: bool = Field(default=False, description="Enable Cylestio tracing")
+    api_url: str = Field(..., description="Cylestio API endpoint URL")
+    access_key: str = Field(..., description="Cylestio API access key")
+    timeout: int = Field(default=10, ge=1, description="HTTP request timeout in seconds")
+    
+    @field_validator("api_url")
+    @classmethod
+    def validate_api_url(cls, v: str) -> str:
+        """Ensure API URL is properly formatted."""
+        v = v.rstrip("/")
+        if not v.startswith(("http://", "https://")):
+            raise ValueError("api_url must start with http:// or https://")
+        return v
+
+
 class Settings(BaseModel):
     """Main settings configuration."""
     
@@ -70,6 +88,7 @@ class Settings(BaseModel):
     interceptors: List[InterceptorConfig] = Field(default_factory=list)
     logging: LoggingConfig = Field(default_factory=LoggingConfig)
     session: SessionConfig = Field(default_factory=SessionConfig)
+    cylestio: Optional[CylestioConfig] = Field(default=None, description="Cylestio tracing configuration")
     
     @classmethod
     def from_yaml(cls, config_path: str) -> "Settings":

--- a/src/interceptors/cylestio_trace/__init__.py
+++ b/src/interceptors/cylestio_trace/__init__.py
@@ -1,0 +1,5 @@
+"""Cylestio trace interceptor for sending events to Cylestio API."""
+
+from .interceptor import CylestioTraceInterceptor
+
+__all__ = ["CylestioTraceInterceptor"]

--- a/src/interceptors/cylestio_trace/api_authentication.py
+++ b/src/interceptors/cylestio_trace/api_authentication.py
@@ -1,0 +1,156 @@
+"""API authentication for Cylestio Monitor.
+
+This module provides authentication functionality for the Cylestio API client,
+including JWT token generation using Descope.
+"""
+
+import logging
+import time
+from typing import Optional, Dict
+
+from descope import AuthException, DescopeClient
+
+# Configure logging
+logger = logging.getLogger(__name__)
+
+# Descope configuration
+DESCOPE_PROJECT_ID = 'P2zF0Fh3eZsfOBM2cqh03EPfa6G4'
+
+
+class DescopeAuthenticator:
+    """Descope authentication client with instance caching.
+    
+    This class provides JWT token exchange functionality using Descope,
+    with a cached Descope client instance for improved performance.
+    """
+    
+    # Class-level cache for singleton instances by access_key
+    _instances: Dict[str, 'DescopeAuthenticator'] = {}
+    
+    def __init__(self, access_key: str, project_id: str = DESCOPE_PROJECT_ID, refresh_buffer_seconds: int = 30) -> None:
+        """Initialize the Descope authenticator.
+        
+        Args:
+            access_key: The access key to use for authentication
+            project_id: The Descope project ID to use for authentication
+            refresh_buffer_seconds: Seconds before expiration to refresh token (default: 30)
+        """
+        self.project_id = project_id
+        self._client: Optional[DescopeClient] = None
+        self._access_key = access_key
+        self._refresh_buffer_seconds = refresh_buffer_seconds
+        
+        # Token caching
+        self._cached_jwt_token: Optional[str] = None
+        self._token_expires_at: Optional[float] = None
+        
+        logger.debug(f"Initialized DescopeAuthenticator with project_id: {project_id} and access_key: {access_key}")
+    
+    @classmethod
+    def get_instance(cls, access_key: str, project_id: str = DESCOPE_PROJECT_ID, refresh_buffer_seconds: int = 30) -> 'DescopeAuthenticator':
+        """Get a singleton instance of DescopeAuthenticator for the given access_key.
+        
+        Args:
+            access_key: The access key to use for authentication
+            project_id: The Descope project ID to use for authentication
+            refresh_buffer_seconds: Seconds before expiration to refresh token (default: 30)
+            
+        Returns:
+            DescopeAuthenticator: Singleton instance for the access_key
+        """
+        if access_key not in cls._instances:
+            cls._instances[access_key] = cls(access_key, project_id, refresh_buffer_seconds)
+        return cls._instances[access_key]
+    
+    def _get_client(self) -> DescopeClient:
+        """Get the cached Descope client instance.
+        
+        Returns:
+            DescopeClient: The cached Descope client instance
+        """
+        if self._client is None:
+            self._client = DescopeClient(project_id=self.project_id)
+            logger.debug("Created new Descope client instance")
+        return self._client
+    
+    def _is_token_expired(self) -> bool:
+        """Check if the cached token is expired or about to expire.
+        
+        Returns:
+            bool: True if token is expired or expires within refresh_buffer_seconds, False otherwise
+        """
+        if self._token_expires_at is None:
+            return True
+        
+        # Check if token expires within the buffer time
+        is_token_expired = time.time() >= (self._token_expires_at - self._refresh_buffer_seconds)
+        if is_token_expired:
+            logger.info("JWT token expired, forcing a fresh exchange on next call")
+        return is_token_expired
+    
+    def invalidate_token(self) -> None:
+        """Invalidate the cached JWT token, forcing a fresh exchange on next call.
+        
+        This method clears the cached token and expiration time. Useful when 
+        authentication errors occur and you need to force token renewal.
+        """
+        self._cached_jwt_token = None
+        self._token_expires_at = None
+        logger.debug("JWT token cache invalidated")
+    
+    def get_jwt_token(self) -> Optional[str]:
+        """Exchange an access key for a JWT token using Descope.
+
+        Returns cached token if still valid, otherwise exchanges access key for new token.
+
+        Returns:
+            Optional[str]: The JWT token if successful, None if failed
+        """
+        if not self._access_key:
+            logger.error("Access key is required for JWT token exchange")
+            return None
+
+        # Return cached token if still valid
+        if self._cached_jwt_token and not self._is_token_expired():
+            return self._cached_jwt_token
+
+        try:
+            # Exchange access key for JWT using cached client
+            resp = self._get_client().exchange_access_key(access_key=self._access_key)
+            logger.debug("Successfully exchanged access key for JWT token")
+            
+            # Extract the JWT token from the response
+            if isinstance(resp, dict):
+                # Based on actual response structure: response['sessionToken']['jwt']
+                session_token = resp.get('sessionToken')
+                if isinstance(session_token, dict):
+                    jwt_token = session_token.get('jwt')
+                    token_exp = session_token.get('exp')
+                    
+                    if jwt_token and token_exp:
+                        # Cache the token and expiration
+                        self._cached_jwt_token = jwt_token
+                        self._token_expires_at = float(token_exp)
+                        
+                        logger.info(f"Refreshed token, updating cache, expires at: {time.ctime(self._token_expires_at)}")
+                        return jwt_token
+                    else:
+                        logger.error("JWT token or expiration not found in sessionToken")
+                        return None
+                else:
+                    logger.error("sessionToken not found or invalid in response")
+                    logger.debug(f"Available response keys: {list(resp.keys())}")
+                    return None
+            else:
+                logger.error(f"Unexpected response type: {type(resp)}")
+                return None
+                
+        except AuthException as e:
+            logger.error(f"Unable to exchange access key for JWT. Status: {e.status_code}, Error: {e.error_message}")
+            return None
+        except Exception as e:
+            logger.error(f"Unexpected error occurred during JWT token exchange: {e}")
+            return None
+
+
+__all__ = ["DescopeAuthenticator"]

--- a/src/interceptors/cylestio_trace/client.py
+++ b/src/interceptors/cylestio_trace/client.py
@@ -1,0 +1,159 @@
+"""HTTP client for Cylestio API integration."""
+import json
+import logging
+from typing import Dict, Any, Optional
+
+import httpx
+
+from .events import CylestioEvent
+from .api_authentication import DescopeAuthenticator
+
+logger = logging.getLogger(__name__)
+
+
+class CylestioAPIError(Exception):
+    """Cylestio API error."""
+    
+    def __init__(self, message: str, status_code: Optional[int] = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class CylestioClient:
+    """HTTP client for sending events to Cylestio API."""
+    
+    def __init__(self, api_url: str, access_key: str, timeout: int = 10):
+        """Initialize Cylestio client.
+        
+        Args:
+            api_url: Cylestio API endpoint URL
+            access_key: API access key for authentication
+            timeout: HTTP request timeout in seconds
+        """
+        self.api_url = api_url.rstrip("/")
+        self.access_key = access_key
+        self.timeout = timeout
+        self._client: Optional[httpx.AsyncClient] = None
+        
+        # Initialize Descope authenticator for JWT token generation
+        self._authenticator = DescopeAuthenticator.get_instance(access_key=access_key)
+    
+    async def __aenter__(self):
+        """Async context manager entry."""
+        # Create client without Authorization header initially
+        self._client = httpx.AsyncClient(
+            timeout=httpx.Timeout(self.timeout),
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "cylestio-gateway/1.0"
+            }
+        )
+        return self
+    
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit."""
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+    
+    async def send_event(self, event: CylestioEvent) -> bool:
+        """Send a single event to Cylestio API.
+        
+        Args:
+            event: CylestioEvent to send
+            
+        Returns:
+            True if successful, False otherwise
+            
+        Raises:
+            CylestioAPIError: If API returns an error
+        """
+        if not self._client:
+            raise RuntimeError("Client not initialized. Use async context manager.")
+        
+        try:
+            # Get JWT token for authorization
+            jwt_token = self._authenticator.get_jwt_token()
+            if not jwt_token:
+                logger.error("Failed to get JWT token for authentication")
+                return False
+            
+            # Convert event to dict for JSON serialization
+            event_data = event.model_dump()
+            
+            # Log the event being sent (at debug level)
+            logger.debug(f"Sending event to Cylestio: {event.name} for session {event.session_id}")
+            
+            # Send HTTP POST request with JWT token
+            response = await self._client.post(
+                f"{self.api_url}/v1/telemetry",
+                json=event_data,
+                headers={"Authorization": f"Bearer {jwt_token}"}
+            )
+            
+            # Check response status
+            if response.status_code == 200 or response.status_code == 201:
+                logger.debug(f"Successfully sent event {event.name}")
+                return True
+            else:
+                # Invalidate token on authentication errors
+                if response.status_code == 401 or response.status_code == 403:
+                    self._authenticator.invalidate_token()
+                    logger.warning("Authentication error occurred, invalidating JWT token to refresh next time")
+                
+                error_msg = f"API returned {response.status_code}: {response.text}"
+                logger.error(f"Failed to send event {event.name}: {error_msg}")
+                raise CylestioAPIError(error_msg, response.status_code)
+                
+        except httpx.TimeoutException:
+            logger.error(f"Timeout sending event {event.name} to Cylestio API")
+            return False
+        except httpx.NetworkError as e:
+            logger.error(f"Network error sending event {event.name}: {e}")
+            return False
+        except Exception as e:
+            logger.error(f"Unexpected error sending event {event.name}: {e}")
+            return False
+    
+    async def send_events_batch(self, events: list[CylestioEvent]) -> Dict[str, int]:
+        """Send multiple events in a batch.
+        
+        Args:
+            events: List of CylestioEvent objects to send
+            
+        Returns:
+            Dict with 'success' and 'failed' counts
+        """
+        if not events:
+            return {"success": 0, "failed": 0}
+        
+        results = {"success": 0, "failed": 0}
+        
+        for event in events:
+            try:
+                success = await self.send_event(event)
+                if success:
+                    results["success"] += 1
+                else:
+                    results["failed"] += 1
+            except Exception as e:
+                logger.error(f"Failed to send event {event.name}: {e}")
+                results["failed"] += 1
+        
+        return results
+    
+    async def health_check(self) -> bool:
+        """Check if Cylestio API is reachable.
+        
+        Returns:
+            True if API is healthy, False otherwise
+        """
+        if not self._client:
+            raise RuntimeError("Client not initialized. Use async context manager.")
+        
+        try:
+            response = await self._client.get(f"{self.api_url}/health")
+            return response.status_code == 200
+        except Exception as e:
+            logger.error(f"Health check failed: {e}")
+            return False

--- a/src/interceptors/cylestio_trace/events.py
+++ b/src/interceptors/cylestio_trace/events.py
@@ -1,0 +1,298 @@
+"""Event models for Cylestio API integration."""
+import uuid
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class EventLevel(str, Enum):
+    """Event level enumeration."""
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+
+
+class EventName(str, Enum):
+    """Cylestio event name enumeration."""
+    LLM_CALL_START = "llm.call.start"
+    LLM_CALL_FINISH = "llm.call.finish"
+    LLM_CALL_ERROR = "llm.call.error"
+    TOOL_EXECUTION = "tool.execution"
+    TOOL_RESULT = "tool.result"
+    SESSION_START = "session.start"
+    SESSION_END = "session.end"
+
+
+def generate_trace_id() -> str:
+    """Generate OpenTelemetry-compatible trace ID (32-char hex)."""
+    return uuid.uuid4().hex + uuid.uuid4().hex[:16]
+
+
+def generate_span_id() -> str:
+    """Generate OpenTelemetry-compatible span ID (16-char hex)."""
+    return uuid.uuid4().hex[:16]
+
+
+class CylestioEvent(BaseModel):
+    """Base Cylestio event model matching API schema."""
+    
+    schema_version: str = Field(default="1.0", description="Event schema version")
+    timestamp: str = Field(default_factory=lambda: datetime.utcnow().isoformat() + "Z")
+    trace_id: str = Field(..., description="OpenTelemetry trace ID")
+    span_id: str = Field(..., description="OpenTelemetry span ID")
+    name: EventName = Field(..., description="Event name")
+    level: EventLevel = Field(default=EventLevel.INFO, description="Event level")
+    agent_id: str = Field(..., description="Agent identifier")
+    session_id: Optional[str] = Field(default=None, description="Session identifier")
+    attributes: Dict[str, Any] = Field(default_factory=dict, description="Event-specific attributes")
+
+
+class LLMCallStartEvent(CylestioEvent):
+    """LLM call start event."""
+    
+    name: EventName = Field(default=EventName.LLM_CALL_START, frozen=True)
+    
+    @classmethod
+    def create(
+        cls,
+        trace_id: str,
+        span_id: str,
+        agent_id: str,
+        vendor: str,
+        model: str,
+        request_data: Dict[str, Any],
+        session_id: Optional[str] = None
+    ) -> "LLMCallStartEvent":
+        """Create LLM call start event."""
+        return cls(
+            trace_id=trace_id,
+            span_id=span_id,
+            agent_id=agent_id,
+            session_id=session_id,
+            attributes={
+                "llm.vendor": vendor,
+                "llm.model": model,
+                "llm.request.data": request_data
+            }
+        )
+
+
+class LLMCallFinishEvent(CylestioEvent):
+    """LLM call finish event."""
+    
+    name: EventName = Field(default=EventName.LLM_CALL_FINISH, frozen=True)
+    
+    @classmethod
+    def create(
+        cls,
+        trace_id: str,
+        span_id: str,
+        agent_id: str,
+        vendor: str,
+        model: str,
+        duration_ms: float,
+        input_tokens: Optional[int] = None,
+        output_tokens: Optional[int] = None,
+        total_tokens: Optional[int] = None,
+        response_content: Optional[List[Dict[str, Any]]] = None,
+        session_id: Optional[str] = None
+    ) -> "LLMCallFinishEvent":
+        """Create LLM call finish event."""
+        attributes = {
+            "llm.vendor": vendor,
+            "llm.model": model,
+            "llm.response.duration_ms": duration_ms
+        }
+        
+        if input_tokens is not None:
+            attributes["llm.usage.input_tokens"] = input_tokens
+        if output_tokens is not None:
+            attributes["llm.usage.output_tokens"] = output_tokens
+        if total_tokens is not None:
+            attributes["llm.usage.total_tokens"] = total_tokens
+        if response_content is not None:
+            attributes["llm.response.content"] = response_content
+            
+        return cls(
+            trace_id=trace_id,
+            span_id=span_id,
+            agent_id=agent_id,
+            session_id=session_id,
+            attributes=attributes
+        )
+
+
+class LLMCallErrorEvent(CylestioEvent):
+    """LLM call error event."""
+    
+    name: EventName = Field(default=EventName.LLM_CALL_ERROR, frozen=True)
+    level: EventLevel = Field(default=EventLevel.ERROR, frozen=True)
+    
+    @classmethod
+    def create(
+        cls,
+        trace_id: str,
+        span_id: str,
+        agent_id: str,
+        vendor: str,
+        model: str,
+        error_message: str,
+        error_type: Optional[str] = None,
+        session_id: Optional[str] = None
+    ) -> "LLMCallErrorEvent":
+        """Create LLM call error event."""
+        attributes = {
+            "llm.vendor": vendor,
+            "llm.model": model,
+            "error.message": error_message
+        }
+        
+        if error_type:
+            attributes["error.type"] = error_type
+            
+        return cls(
+            trace_id=trace_id,
+            span_id=span_id,
+            agent_id=agent_id,
+            session_id=session_id,
+            attributes=attributes
+        )
+
+
+class ToolExecutionEvent(CylestioEvent):
+    """Tool execution event."""
+    
+    name: EventName = Field(default=EventName.TOOL_EXECUTION, frozen=True)
+    
+    @classmethod
+    def create(
+        cls,
+        trace_id: str,
+        span_id: str,
+        agent_id: str,
+        tool_name: str,
+        tool_params: Dict[str, Any],
+        framework_name: Optional[str] = None,
+        session_id: Optional[str] = None
+    ) -> "ToolExecutionEvent":
+        """Create tool execution event."""
+        attributes = {
+            "tool.name": tool_name,
+            "tool.params": tool_params
+        }
+        
+        if framework_name:
+            attributes["framework.name"] = framework_name
+            
+        return cls(
+            trace_id=trace_id,
+            span_id=span_id,
+            agent_id=agent_id,
+            session_id=session_id,
+            attributes=attributes
+        )
+
+
+class ToolResultEvent(CylestioEvent):
+    """Tool result event."""
+    
+    name: EventName = Field(default=EventName.TOOL_RESULT, frozen=True)
+    
+    @classmethod
+    def create(
+        cls,
+        trace_id: str,
+        span_id: str,
+        agent_id: str,
+        tool_name: str,
+        status: str,
+        execution_time_ms: float,
+        result: Optional[Any] = None,
+        error_message: Optional[str] = None,
+        session_id: Optional[str] = None
+    ) -> "ToolResultEvent":
+        """Create tool result event."""
+        attributes = {
+            "tool.name": tool_name,
+            "tool.status": status,
+            "tool.execution_time_ms": execution_time_ms
+        }
+        
+        if result is not None:
+            attributes["tool.result"] = result
+        if error_message:
+            attributes["error.message"] = error_message
+            
+        return cls(
+            trace_id=trace_id,
+            span_id=span_id,
+            agent_id=agent_id,
+            session_id=session_id,
+            attributes=attributes
+        )
+
+
+class SessionStartEvent(CylestioEvent):
+    """Session start event."""
+    
+    name: EventName = Field(default=EventName.SESSION_START, frozen=True)
+    
+    @classmethod
+    def create(
+        cls,
+        trace_id: str,
+        span_id: str,
+        agent_id: str,
+        session_id: str,
+        user_id: Optional[str] = None,
+        client_type: Optional[str] = None
+    ) -> "SessionStartEvent":
+        """Create session start event."""
+        attributes = {
+            "session.id": session_id
+        }
+        
+        if user_id:
+            attributes["user.id"] = user_id
+        if client_type:
+            attributes["client.type"] = client_type
+            
+        return cls(
+            trace_id=trace_id,
+            span_id=span_id,
+            agent_id=agent_id,
+            session_id=session_id,
+            attributes=attributes
+        )
+
+
+class SessionEndEvent(CylestioEvent):
+    """Session end event."""
+    
+    name: EventName = Field(default=EventName.SESSION_END, frozen=True)
+    
+    @classmethod
+    def create(
+        cls,
+        trace_id: str,
+        span_id: str,
+        agent_id: str,
+        session_id: str,
+        duration_ms: float,
+        events_count: int
+    ) -> "SessionEndEvent":
+        """Create session end event."""
+        return cls(
+            trace_id=trace_id,
+            span_id=span_id,
+            agent_id=agent_id,
+            session_id=session_id,
+            attributes={
+                "session.id": session_id,
+                "session.duration_ms": duration_ms,
+                "session.events_count": events_count
+            }
+        )

--- a/src/interceptors/cylestio_trace/interceptor.py
+++ b/src/interceptors/cylestio_trace/interceptor.py
@@ -1,0 +1,349 @@
+"""Cylestio trace interceptor for sending events to Cylestio API."""
+import hashlib
+import logging
+import time
+from typing import Any, Dict, List, Optional
+
+from ...proxy.interceptor_base import BaseInterceptor, LLMRequestData, LLMResponseData
+from .client import CylestioClient, CylestioAPIError
+from .events import (
+    LLMCallStartEvent, LLMCallFinishEvent, LLMCallErrorEvent,
+    ToolExecutionEvent, ToolResultEvent,
+    SessionStartEvent, SessionEndEvent,
+    generate_span_id
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CylestioTraceInterceptor(BaseInterceptor):
+    """Interceptor for sending trace events to Cylestio API."""
+    
+    def __init__(self, config: Dict[str, Any]):
+        """Initialize Cylestio trace interceptor.
+        
+        Args:
+            config: Configuration dict with Cylestio settings
+        """
+        super().__init__(config)
+        
+        # Extract Cylestio configuration
+        self.api_url = config.get("api_url")
+        self.access_key = config.get("access_key")
+        self.timeout = config.get("timeout", 10)
+        
+        # Validate required configuration
+        if not all([self.api_url, self.access_key]):
+            raise ValueError("Cylestio interceptor requires api_url and access_key")
+        
+        # Track sessions for session events
+        self._active_sessions: Dict[str, float] = {}  # session_id -> start_time
+        self._session_event_counts: Dict[str, int] = {}  # session_id -> event_count
+    
+    @property
+    def name(self) -> str:
+        """Return the name of this interceptor."""
+        return "cylestio_trace"
+    
+    def _get_agent_id(self, request_data: LLMRequestData) -> str:
+        """Get agent ID derived from system prompt hash (calculated per request)."""
+        # Extract system prompt from request body (TODO: is this OpenAI?)
+        system_prompt = ""
+        if request_data.body:
+            messages = request_data.body.get("messages", [])
+            for message in messages:
+                if message.get("role") == "system":
+                    content = message.get("content", "")
+                    if isinstance(content, str):
+                        system_prompt = content
+                    break
+        
+        # Fallback to default if no system prompt found
+        if not system_prompt:
+            system_prompt = request_data.body.get("system", "default-agent")
+        
+        # Generate agent ID as hash of system prompt
+        hash_obj = hashlib.md5(system_prompt.encode())
+        return f"agent-{hash_obj.hexdigest()[:12]}"
+    
+    def _session_to_trace_span_id(self, session_id: str) -> str:
+        """Convert session ID to OpenTelemetry-compatible trace/span ID (32-char hex).
+        
+        For now, trace_id and span_id are identical and derived from session_id.
+        """
+        if not session_id:
+            return generate_span_id() + generate_span_id()  # 32 chars
+        
+        # Create deterministic ID from session ID
+        hash_obj = hashlib.md5(session_id.encode())
+        return hash_obj.hexdigest()  # 32-char hex string
+    
+    def _extract_usage_tokens(self, response_body: Optional[Dict[str, Any]]) -> tuple[Optional[int], Optional[int], Optional[int]]:
+        """Extract token usage from response body.
+        
+        Returns:
+            Tuple of (input_tokens, output_tokens, total_tokens)
+        """
+        if not response_body:
+            return None, None, None
+        
+        # Check for OpenAI format
+        usage = response_body.get("usage", {})
+        if usage:
+            return (
+                usage.get("prompt_tokens"),
+                usage.get("completion_tokens"),
+                usage.get("total_tokens")
+            )
+        
+        # Check for Anthropic format
+        if "usage" in response_body:
+            usage = response_body["usage"]
+            return (
+                usage.get("input_tokens"),
+                usage.get("output_tokens"),
+                usage.get("input_tokens", 0) + usage.get("output_tokens", 0) if 
+                usage.get("input_tokens") and usage.get("output_tokens") else None
+            )
+        
+        return None, None, None
+    
+    def _extract_response_content(self, response_body: Optional[Dict[str, Any]]) -> Optional[List[Dict[str, Any]]]:
+        """Extract response content from response body."""
+        if not response_body:
+            return None
+        
+        # OpenAI format
+        choices = response_body.get("choices", [])
+        if choices:
+            content = []
+            for choice in choices:
+                message = choice.get("message", {})
+                if "content" in message:
+                    content.append({"text": message["content"]})
+            return content if content else None
+        
+        # Anthropic format
+        if "content" in response_body:
+            anthropic_content = response_body["content"]
+            if isinstance(anthropic_content, list):
+                content = []
+                for item in anthropic_content:
+                    if item.get("type") == "text":
+                        content.append({"text": item.get("text", "")})
+                return content if content else None
+            elif isinstance(anthropic_content, str):
+                return [{"text": anthropic_content}]
+        
+        return None
+    
+    async def _send_event_safe(self, event) -> bool:
+        """Send event with error handling."""
+        try:
+            async with CylestioClient(self.api_url, self.access_key, self.timeout) as client:
+                return await client.send_event(event)
+        except CylestioAPIError as e:
+            logger.error(f"Cylestio API error: {e}")
+            return False
+        except Exception as e:
+            logger.error(f"Unexpected error sending Cylestio event: {e}")
+            return False
+    
+    async def before_request(self, request_data: LLMRequestData) -> Optional[LLMRequestData]:
+        """Send LLM call start event and session start if new session."""
+        if not self.enabled:
+            return None
+        
+        session_id = request_data.session_id
+        if not session_id:
+            logger.warning("No session ID available for Cylestio tracing")
+            return None
+
+        # Use same ID for both trace and span (derived from session)
+        trace_span_id = self._session_to_trace_span_id(session_id)
+        trace_id = trace_span_id
+        span_id = trace_span_id
+        
+        # Handle session start event
+        if request_data.is_new_session:
+            self._active_sessions[session_id] = time.time()
+            self._session_event_counts[session_id] = 0
+            
+            session_start_event = SessionStartEvent.create(
+                trace_id=trace_id,
+                span_id=span_id,  # Same as trace_id
+                agent_id=self._get_agent_id(request_data),
+                session_id=session_id,
+                client_type="gateway"
+            )
+            await self._send_event_safe(session_start_event)
+            self._session_event_counts[session_id] += 1
+        
+        # Send LLM call start event
+        if request_data.provider and request_data.model:
+            llm_start_event = LLMCallStartEvent.create(
+                trace_id=trace_id,
+                span_id=span_id,
+                agent_id=self._get_agent_id(request_data),
+                vendor=request_data.provider,
+                model=request_data.model,
+                request_data=request_data.body or {},
+                session_id=session_id
+            )
+            await self._send_event_safe(llm_start_event)
+            
+            if session_id in self._session_event_counts:
+                self._session_event_counts[session_id] += 1
+        
+        # Handle tool execution events if present
+        if request_data.has_tool_results:
+            for tool_result in request_data.tool_results:
+                tool_event = ToolExecutionEvent.create(
+                    trace_id=trace_id,
+                    span_id=span_id,
+                    agent_id=self._get_agent_id(request_data),
+                    tool_name=tool_result.get("name", "unknown"),
+                    tool_params=tool_result.get("params", {}),
+                    session_id=session_id
+                )
+                await self._send_event_safe(tool_event)
+                
+                if session_id in self._session_event_counts:
+                    self._session_event_counts[session_id] += 1
+        
+        # Store trace/span ID for use in response (they're the same now)
+        request_data.metadata["cylestio_trace_span_id"] = trace_span_id
+        
+        return None
+    
+    async def after_response(self, request_data: LLMRequestData, response_data: LLMResponseData) -> Optional[LLMResponseData]:
+        """Send LLM call finish event and tool result events."""
+        if not self.enabled:
+            return None
+        
+        session_id = request_data.session_id
+        if not session_id:
+            return None
+        
+        # Get trace/span ID from request metadata (they're the same)
+        trace_span_id = request_data.metadata.get("cylestio_trace_span_id")
+        
+        if not trace_span_id:
+            logger.warning("Missing trace/span ID for Cylestio response event")
+            return None
+        
+        trace_id = trace_span_id
+        span_id = trace_span_id
+        
+        # Extract token usage and response content
+        input_tokens, output_tokens, total_tokens = self._extract_usage_tokens(response_data.body)
+        response_content = self._extract_response_content(response_data.body)
+        
+        # Send LLM call finish event
+        if request_data.provider and request_data.model:
+            llm_finish_event = LLMCallFinishEvent.create(
+                trace_id=trace_id,
+                span_id=span_id,
+                agent_id=self._get_agent_id(request_data),
+                vendor=request_data.provider,
+                model=request_data.model,
+                duration_ms=response_data.duration_ms,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=total_tokens,
+                response_content=response_content,
+                session_id=session_id
+            )
+            await self._send_event_safe(llm_finish_event)
+            
+            if session_id in self._session_event_counts:
+                self._session_event_counts[session_id] += 1
+        
+        # Handle tool result events if present
+        if response_data.has_tool_requests:
+            for tool_request in response_data.tool_uses_request:
+                tool_result_event = ToolResultEvent.create(
+                    trace_id=trace_id,
+                    span_id=span_id,
+                    agent_id=self._get_agent_id(request_data),
+                    tool_name=tool_request.get("name", "unknown"),
+                    status="success",  # Assume success for now
+                    execution_time_ms=0.0,  # Not available
+                    result=tool_request.get("result"),
+                    session_id=session_id
+                )
+                await self._send_event_safe(tool_result_event)
+                
+                if session_id in self._session_event_counts:
+                    self._session_event_counts[session_id] += 1
+        
+        return None
+    
+    async def on_error(self, request_data: LLMRequestData, error: Exception) -> None:
+        """Send LLM call error event."""
+        if not self.enabled:
+            return
+        
+        session_id = request_data.session_id
+        if not session_id:
+            return
+        
+        # Get trace/span ID from request metadata (they're the same)
+        trace_span_id = request_data.metadata.get("cylestio_trace_span_id")
+        
+        if not trace_span_id:
+            # Generate new ID if not available
+            trace_span_id = self._session_to_trace_span_id(session_id)
+        
+        trace_id = trace_span_id
+        span_id = trace_span_id
+        
+        # Send LLM call error event
+        if request_data.provider and request_data.model:
+            llm_error_event = LLMCallErrorEvent.create(
+                trace_id=trace_id,
+                span_id=span_id,
+                agent_id=self._get_agent_id(request_data),
+                vendor=request_data.provider,
+                model=request_data.model,
+                error_message=str(error),
+                error_type=type(error).__name__,
+                session_id=session_id
+            )
+            await self._send_event_safe(llm_error_event)
+            
+            if session_id in self._session_event_counts:
+                self._session_event_counts[session_id] += 1
+    
+    async def end_session(self, session_id: str) -> None:
+        """Send session end event for a given session.
+        
+        This should be called when a session ends.
+        """
+        if not self.enabled or session_id not in self._active_sessions:
+            return
+        
+        start_time = self._active_sessions[session_id]
+        duration_ms = (time.time() - start_time) * 1000
+        event_count = self._session_event_counts.get(session_id, 0)
+        
+        trace_span_id = self._session_to_trace_span_id(session_id)
+        
+        # Note: We would need request_data to get agent_id, but this method doesn't have it
+        # For session end events, we use a generic agent_id
+        default_agent_id = "agent-unknown"
+        
+        session_end_event = SessionEndEvent.create(
+            trace_id=trace_span_id,
+            span_id=trace_span_id,
+            agent_id=default_agent_id,
+            session_id=session_id,
+            duration_ms=duration_ms,
+            events_count=event_count
+        )
+        
+        await self._send_event_safe(session_end_event)
+        
+        # Clean up session tracking
+        del self._active_sessions[session_id]
+        del self._session_event_counts[session_id]

--- a/src/main.py
+++ b/src/main.py
@@ -16,6 +16,7 @@ from src.proxy.middleware import LLMMiddleware
 from src.proxy.interceptor_manager import interceptor_manager
 from src.interceptors.printer import PrinterInterceptor
 from src.interceptors.message_logger import MessageLoggerInterceptor
+from src.interceptors.cylestio_trace import CylestioTraceInterceptor
 from src.proxy.handler import ProxyHandler
 from src.utils.logger import get_logger, setup_logging
 
@@ -69,6 +70,7 @@ def create_app(config: Settings) -> FastAPI:
     # Register interceptor types
     interceptor_manager.register_interceptor("printer", PrinterInterceptor)
     interceptor_manager.register_interceptor("message_logger", MessageLoggerInterceptor)
+    interceptor_manager.register_interceptor("cylestio_trace", CylestioTraceInterceptor)
     
     # Create interceptors from configuration
     interceptors = interceptor_manager.create_interceptors(config.interceptors)
@@ -233,6 +235,15 @@ def generate_example_config(output_path: str):
                     "log_requests": True,
                     "log_responses": True,
                     "log_body": True
+                }
+            },
+            {
+                "type": "cylestio_trace",
+                "enabled": False,
+                "config": {
+                    "api_url": "https://api.cylestio.com",
+                    "access_key": "your-cylestio-access-key-here",
+                    "timeout": 10
                 }
             }
         ],


### PR DESCRIPTION
## Summary
- Added Cylestio trace interceptor to send OpenTelemetry-compatible events to Cylestio API
- Implemented JWT authentication using Descope for secure API access
- Dynamic agent identification based on system prompt hash

## Key Features
### Event Types Supported
- **LLM Events**: call start/finish/error with token usage tracking
- **Tool Events**: execution and result events
- **Session Events**: start/end with duration and event count

### Authentication
- Integrated Descope JWT authentication
- Access key exchange for short-lived JWT tokens
- Automatic token refresh and invalidation on auth errors

### Configuration
- Simple YAML configuration with environment variable support
- Only requires `api_url` and `access_key`
- Agent ID automatically derived from system prompt (no config needed)

### Design Decisions
- **Trace/Span IDs**: Both use same value derived from session_id for simplicity
- **Agent ID**: Calculated per request from system prompt hash (supports multi-agent)
- **Direct HTTP calls**: Synchronous for now (async optimization documented in TODOs.md)

## Files Changed
- `src/interceptors/cylestio_trace/` - New interceptor implementation
  - `interceptor.py` - Main interceptor logic
  - `events.py` - Cylestio event models
  - `client.py` - HTTP client with JWT auth
  - `api_authentication.py` - Descope JWT authentication
- `src/config/settings.py` - Added CylestioConfig
- `src/main.py` - Registered cylestio_trace interceptor
- `examples/configs/anthropic-basic.yaml` - Added example configuration
- `requirements.txt` - Added descope dependency
- `TODOs.md` - Documented future async optimizations

## Testing
Tested with local Cylestio instance on localhost:8000

## Example Usage
```yaml
interceptors:
  - type: "cylestio_trace"
    enabled: true
    config:
      api_url: "http://localhost:8000"
      access_key: "${CYLESTIO_ACCESS_KEY}"
```

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>