### PR TITLE
Add system environment enrichment to all events

### DIFF
--- a/src/interceptors/cylestio_trace/events.py
+++ b/src/interceptors/cylestio_trace/events.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from .system_info import get_cached_system_info
+
 
 class EventLevel(str, Enum):
     """Event level enumeration."""
@@ -48,7 +50,11 @@ class CylestioEvent(BaseModel):
     agent_id: str = Field(..., description="Agent identifier")
     session_id: Optional[str] = Field(default=None, description="Session identifier")
     attributes: Dict[str, Any] = Field(default_factory=dict, description="Event-specific attributes")
-
+    
+    def model_post_init(self, __context: Any) -> None:
+        """Post-initialization to enrich with system information."""
+        system_info = get_cached_system_info()
+        self.attributes.update(system_info)
 
 class LLMCallStartEvent(CylestioEvent):
     """LLM call start event."""

--- a/src/interceptors/cylestio_trace/system_info.py
+++ b/src/interceptors/cylestio_trace/system_info.py
@@ -1,0 +1,25 @@
+"""System information utilities for event enrichment."""
+import platform
+import socket
+import sys
+from typing import Dict, Any
+
+
+def get_system_info() -> Dict[str, Any]:
+    """Get system information for event enrichment."""
+    return {
+        "os.type": platform.system(),
+        "os.version": platform.release(),
+        "env.python.version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        "env.machine.type": platform.machine(),
+        "host.name": socket.gethostname()
+    }
+
+
+# Cache system info since it doesn't change during runtime
+_SYSTEM_INFO = get_system_info()
+
+
+def get_cached_system_info() -> Dict[str, Any]:
+    """Get cached system information for performance."""
+    return _SYSTEM_INFO


### PR DESCRIPTION
## Summary
- Added automatic enrichment of all Cylestio events with system information
- Created system_info utility module for collecting OS and environment details
- Modified CylestioEvent base class to automatically include enrichment fields

## Changes
- Added `src/interceptors/cylestio_trace/system_info.py` for system information collection
- Enhanced `CylestioEvent` base class with `model_post_init` method for automatic enrichment
- All events now include: os.type, os.version, env.python.version, env.machine.type, host.name

## Test plan
- [x] Verified all event types inherit enrichment automatically
- [x] Confirmed system information is collected correctly
- [x] Tested with LLM call events, tool events, and session events

🤖 Generated with [Claude Code](https://claude.ai/code)