### PR TITLE
Fix provider-specific auth header injection and duplication

### DIFF
--- a/src/providers/anthropic.py
+++ b/src/providers/anthropic.py
@@ -311,3 +311,13 @@ class AnthropicProvider(BaseProvider):
                 events.append(tool_execution_event)
         
         return events
+
+    def get_auth_headers(self) -> Dict[str, str]:
+        """Return Anthropic-specific auth headers.
+        
+        Uses x-api-key: <api_key> when an API key is configured.
+        """
+        api_key = self.get_api_key()
+        if not api_key:
+            return {}
+        return {"x-api-key": api_key}

--- a/src/providers/base.py
+++ b/src/providers/base.py
@@ -146,6 +146,21 @@ class BaseProvider(ABC):
         """
         return [], last_processed_index
     
+    def get_auth_headers(self) -> Dict[str, str]:
+        """Return provider-specific auth headers if applicable.
+        
+        Default implementation uses `get_api_key` and returns an empty dict
+        when no API key is configured.
+        
+        Returns:
+            Dict of header name to value for authentication
+        """
+        api_key = self.get_api_key()
+        if not api_key:
+            return {}
+        # Base provider does not assume header format; concrete providers should override
+        return {}
+    
     def extract_response_events(self, response_body: Optional[Dict[str, Any]], 
                               session_id: str, duration_ms: float, 
                               tool_uses: List[Dict[str, Any]], 

--- a/src/providers/openai.py
+++ b/src/providers/openai.py
@@ -428,3 +428,13 @@ class OpenAIProvider(BaseProvider):
                 events.append(tool_execution_event)
         
         return events
+    
+    def get_auth_headers(self) -> Dict[str, str]:
+        """Return OpenAI-specific auth headers.
+        
+        Uses Authorization: Bearer <api_key> when an API key is configured.
+        """
+        api_key = self.get_api_key()
+        if not api_key:
+            return {}
+        return {"Authorization": f"Bearer {api_key}"}

--- a/src/proxy/handler.py
+++ b/src/proxy/handler.py
@@ -39,19 +39,35 @@ class ProxyHandler:
         Returns:
             Modified headers dict
         """
-        # Copy headers, excluding host-related ones
-        excluded_headers = {"host", "content-length"}
-        headers = {
-            k: v for k, v in request_headers.items() 
-            if k.lower() not in excluded_headers
-        }
-        
-        # Add API key from provider
-        api_key = self.provider.get_api_key()
-        if api_key:
-            headers["Authorization"] = f"Bearer {api_key}"
-        
-        return headers
+        # Exclude hop-by-hop and internal headers
+        excluded_headers = {"host", "content-length", "transfer-encoding"}
+        def is_internal_header(key: str) -> bool:
+            return key.lower().startswith("x-cylestio-")
+
+        # Build a case-insensitive map while preserving original casing for non-sensitive headers
+        canonical_headers: Dict[str, str] = {}
+        lower_to_original: Dict[str, str] = {}
+        for key, value in request_headers.items():
+            lower_key = key.lower()
+            if lower_key in excluded_headers or is_internal_header(key):
+                continue
+            # First occurrence preserves the original casing
+            if lower_key not in lower_to_original:
+                lower_to_original[lower_key] = key
+            canonical_headers[lower_to_original[lower_key]] = value
+
+        # Determine if client already supplied any auth header
+        has_client_auth = any(k.lower() in ("authorization", "x-api-key") for k in canonical_headers.keys())
+
+        # Merge provider auth headers only if client did not supply one
+        if not has_client_auth:
+            provider_auth_headers = self.provider.get_auth_headers()
+            for k, v in provider_auth_headers.items():
+                # Avoid duplicates by lower-case comparison
+                if k.lower() not in (key.lower() for key in canonical_headers.keys()):
+                    canonical_headers[k] = v
+
+        return canonical_headers
     
     def _is_streaming_request(self, body: Any) -> bool:
         """Check if request is for streaming response.

--- a/tests/integration/test_proxy_flow.py
+++ b/tests/integration/test_proxy_flow.py
@@ -1,5 +1,8 @@
 from fastapi import Response
 from fastapi.testclient import TestClient
+import pytest
+from src.main import create_app
+from src.config.settings import Settings
 
 
 def test_proxy_non_streaming_request_returns_upstream_result(client: TestClient, monkeypatch) -> None:
@@ -30,3 +33,112 @@ def test_proxy_non_streaming_request_returns_upstream_result(client: TestClient,
     assert response.status_code == 200
     assert response.headers.get("content-type") == "application/json"
     assert response.json() == {"result": "success"}
+
+
+def test_openai_auth_header_injected_when_absent(client: TestClient, monkeypatch) -> None:
+    """When client omits Authorization, inject provider Authorization header."""
+
+    captured_headers = {}
+
+    async def mock_handle_standard_request(self, method, url, headers, content):  # noqa: ARG001
+        nonlocal captured_headers
+        captured_headers = headers
+        return Response(content=b'{}', status_code=200, media_type="application/json")
+
+    from src.proxy.handler import ProxyHandler
+    monkeypatch.setattr(ProxyHandler, "_handle_standard_request", mock_handle_standard_request)
+
+    response = client.post("/v1/chat/completions", json={"model": "gpt-3.5-turbo"})
+    assert response.status_code == 200
+    # Should inject Authorization: Bearer sk-test (case-insensitive)
+    lc = {k.lower(): v for k, v in captured_headers.items()}
+    assert lc.get("authorization") == "Bearer sk-test"
+
+
+def test_openai_preserve_client_authorization_header(client: TestClient, monkeypatch) -> None:
+    """When client provides Authorization, do not override with provider credentials."""
+
+    captured_headers = {}
+
+    async def mock_handle_standard_request(self, method, url, headers, content):  # noqa: ARG001
+        nonlocal captured_headers
+        captured_headers = headers
+        return Response(content=b'{}', status_code=200, media_type="application/json")
+
+    from src.proxy.handler import ProxyHandler
+    monkeypatch.setattr(ProxyHandler, "_handle_standard_request", mock_handle_standard_request)
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={"model": "gpt-3.5-turbo"},
+        headers={"Authorization": "Bearer client-key"},
+    )
+    assert response.status_code == 200
+    # Should preserve client's Authorization and not double-inject (case-insensitive)
+    lc = {k.lower(): v for k, v in captured_headers.items()}
+    assert lc.get("authorization") == "Bearer client-key"
+
+
+def test_anthropic_auth_header_injected_and_preserved(monkeypatch) -> None:
+    """For Anthropic provider, inject x-api-key when absent; preserve when present."""
+
+    # Build an Anthropic-configured app and client
+    settings = Settings(llm={"base_url": "https://api.anthropic.com", "type": "anthropic", "api_key": "anthropic-key"})
+    app = create_app(settings)
+    local_client = TestClient(app)
+
+    from src.proxy.handler import ProxyHandler
+
+    # Case 1: Absent → inject
+    captured_headers = {}
+
+    async def mock_handle_standard_request(self, method, url, headers, content):  # noqa: ARG001
+        nonlocal captured_headers
+        captured_headers = headers
+        return Response(content=b'{}', status_code=200, media_type="application/json")
+
+    monkeypatch.setattr(ProxyHandler, "_handle_standard_request", mock_handle_standard_request)
+
+    resp = local_client.post("/v1/messages", json={"model": "claude-3-5-sonnet-20241022", "messages": []})
+    assert resp.status_code == 200
+    lc = {k.lower(): v for k, v in captured_headers.items()}
+    assert lc.get("x-api-key") == "anthropic-key"
+    assert "authorization" not in lc
+
+    # Case 2: Present → preserve
+    captured_headers = {}
+    resp = local_client.post(
+        "/v1/messages",
+        json={"model": "claude-3-5-sonnet-20241022", "messages": []},
+        headers={"x-api-key": "client-key"},
+    )
+    assert resp.status_code == 200
+    lc = {k.lower(): v for k, v in captured_headers.items()}
+    assert lc.get("x-api-key") == "client-key"
+
+
+def test_internal_headers_are_not_forwarded(client: TestClient, monkeypatch) -> None:
+    """Verify that x-cylestio-* headers are stripped before forwarding."""
+
+    captured_headers = {}
+
+    async def mock_handle_standard_request(self, method, url, headers, content):  # noqa: ARG001
+        nonlocal captured_headers
+        captured_headers = headers
+        return Response(content=b'{}', status_code=200, media_type="application/json")
+
+    from src.proxy.handler import ProxyHandler
+    monkeypatch.setattr(ProxyHandler, "_handle_standard_request", mock_handle_standard_request)
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={"model": "gpt-3.5-turbo"},
+        headers={
+            "X-Cylestio-Trace-Id": "abc123",
+            "X-Cylestio-Debug": "1",
+        },
+    )
+    assert response.status_code == 200
+    lc = {k.lower(): v for k, v in captured_headers.items()}
+    assert "x-cylestio-trace-id" not in lc
+    assert "x-cylestio-debug" not in lc


### PR DESCRIPTION
### Summary
Align proxy authentication header handling with provider requirements:
- OpenAI uses Authorization: Bearer <key>
- Anthropic uses x-api-key: <key>
- Do not override client-supplied credentials; avoid duplicates; normalize case

### What changed
- Providers
  - OpenAI and Anthropic: expose provider-specific auth headers

- Proxy
  - Normalize and merge headers case-insensitively in ProxyHandler._prepare_headers
  - Inject provider auth only if request lacks authorization or x-api-key
  - Exclude hop-by-hop/internal headers: host, content-length, transfer-encoding, x-cylestio-*
- Tests
  - Integration tests to validate injection vs preservation and header exclusions

### Rationale
Previously we unconditionally injected OpenAI-style Authorization, causing overwrites/duplication and breaking Anthropic. This implements provider-aware auth and correct merging.

### Behavior
- OpenAI
  - If client omits Authorization, inject Authorization: Bearer <key>
  - If client provides Authorization, preserve it; do not double-inject
- Anthropic
  - If client omits x-api-key, inject x-api-key: <key>
  - If client provides x-api-key, preserve it; do not double-inject
- Common
  - Case-insensitive header handling
  - Strip host, content-length, transfer-encoding, and x-cylestio-* from outbound

### Testing
- Integration suite validates:
  - Injection when absent; preservation when present
  - Internal and hop-by-hop exclusions
- All integration tests pass locally
