### PR TITLE
fix: use tomli instead of tomllib for Python 3.9 compatibility

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -30,8 +30,9 @@ jobs:
       - name: 📋 Get version from pyproject.toml
         id: get-version
         run: |
-          VERSION=$(python -c "import tomllib; \
-            print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          pip install tomli
+          VERSION=$(python -c "import tomli; \
+            print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Package version: $VERSION"
 


### PR DESCRIPTION
- tomllib was added in Python 3.11, but we support Python 3.9+
- Use tomli package which provides the same functionality