### PR TITLE
fix: use simple grep/sed to extract version

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -30,13 +30,7 @@ jobs:
       - name: 📋 Get version from pyproject.toml
         id: get-version
         run: |
-          VERSION=$(python -c "
-          import re
-          with open('pyproject.toml', 'r') as f:
-              content = f.read()
-              match = re.search(r'version = \"([^\"]+)\"', content)
-              print(match.group(1) if match else 'unknown')
-          ")
+          VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Package version: $VERSION"
 


### PR DESCRIPTION
- No Python dependencies needed
- Just use basic shell commands that always work