### PR TITLE
Add enhanced session start event attributes (vendor, model, tools, prompt)

### DIFF
--- a/src/events/types.py
+++ b/src/events/types.py
@@ -227,7 +227,11 @@ class SessionStartEvent(BaseEvent):
         agent_id: str,
         session_id: str,
         user_id: Optional[str] = None,
-        client_type: Optional[str] = None
+        client_type: Optional[str] = None,
+        vendor: Optional[str] = None,
+        model: Optional[str] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        prompt: Optional[str] = None
     ) -> "SessionStartEvent":
         """Create session start event."""
         attributes = {
@@ -238,6 +242,14 @@ class SessionStartEvent(BaseEvent):
             attributes["user.id"] = user_id
         if client_type:
             attributes["client.type"] = client_type
+        if vendor:
+            attributes["llm.vendor"] = vendor
+        if model:
+            attributes["llm.model"] = model
+        if tools:
+            attributes["tools"] = tools
+        if prompt:
+            attributes["prompt"] = prompt
             
         return cls(
             trace_id=trace_id,

--- a/src/providers/anthropic.py
+++ b/src/providers/anthropic.py
@@ -124,6 +124,13 @@ class AnthropicProvider(BaseProvider):
         # Default if no system message found
         return "default-system"
     
+    def _extract_tools_for_session(self, body: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
+        """Extract tools from request body for session event."""
+        tools = body.get("tools", [])
+        if tools and isinstance(tools, list):
+            return tools
+        return None
+    
     
     def _extract_usage_tokens(self, response_body: Optional[Dict[str, Any]]) -> tuple[Optional[int], Optional[int], Optional[int]]:
         """Extract token usage from response body.
@@ -198,12 +205,20 @@ class AnthropicProvider(BaseProvider):
             span_id = self.generate_new_span_id()
             self.update_session_span_id(session_id, span_id)
             
+            # Extract tools and prompt for session event
+            tools = self._extract_tools_for_session(body)
+            prompt = self._extract_system_prompt(body)
+            
             session_start_event = SessionStartEvent.create(
                 trace_id=trace_id,
                 span_id=span_id,
                 agent_id=agent_id,
                 session_id=session_id,
-                client_type="gateway"
+                client_type="gateway",
+                vendor=self.name,
+                model=session_info.model,
+                tools=tools,
+                prompt=prompt
             )
             events.append(session_start_event)
         

--- a/tests/providers/test_session_start_attributes.py
+++ b/tests/providers/test_session_start_attributes.py
@@ -1,0 +1,630 @@
+"""Tests for session start event attributes functionality."""
+import pytest
+from src.providers.anthropic import AnthropicProvider
+from src.providers.openai import OpenAIProvider
+from src.providers.base import SessionInfo
+from src.events.types import SessionStartEvent
+
+
+class TestSessionStartEventAttributes:
+    """Test suite for session start event attributes across providers."""
+    
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.anthropic_provider = AnthropicProvider()
+        self.openai_provider = OpenAIProvider()
+    
+    def test_session_start_event_create_with_all_attributes(self):
+        """Test SessionStartEvent.create() with all new attributes."""
+        tools = [
+            {
+                "name": "add",
+                "description": "Add two numbers",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "number"},
+                        "b": {"type": "number"}
+                    }
+                }
+            }
+        ]
+        
+        event = SessionStartEvent.create(
+            trace_id="test-trace-123",
+            span_id="test-span-456", 
+            agent_id="test-agent",
+            session_id="test-session-789",
+            user_id="test-user",
+            client_type="gateway",
+            vendor="anthropic",
+            model="claude-3-haiku-20240307",
+            tools=tools,
+            prompt="You are a helpful assistant."
+        )
+        
+        # Verify basic attributes
+        assert event.trace_id == "test-trace-123"
+        assert event.span_id == "test-span-456"
+        assert event.agent_id == "test-agent"
+        assert event.session_id == "test-session-789"
+        assert event.name == "session.start"
+        
+        # Verify new attributes
+        assert event.attributes["llm.vendor"] == "anthropic"
+        assert event.attributes["llm.model"] == "claude-3-haiku-20240307"
+        assert event.attributes["tools"] == tools
+        assert event.attributes["prompt"] == "You are a helpful assistant."
+        
+        # Verify existing attributes still work
+        assert event.attributes["user.id"] == "test-user"
+        assert event.attributes["client.type"] == "gateway"
+        assert event.attributes["session.id"] == "test-session-789"
+    
+    def test_session_start_event_create_with_optional_attributes(self):
+        """Test SessionStartEvent.create() with only some new attributes."""
+        event = SessionStartEvent.create(
+            trace_id="test-trace-123",
+            span_id="test-span-456",
+            agent_id="test-agent", 
+            session_id="test-session-789",
+            vendor="openai",
+            model="gpt-4"
+            # tools and prompt not provided
+        )
+        
+        # Verify provided attributes
+        assert event.attributes["llm.vendor"] == "openai"
+        assert event.attributes["llm.model"] == "gpt-4"
+        
+        # Verify optional attributes are not present
+        assert "tools" not in event.attributes
+        assert "prompt" not in event.attributes
+        
+        # Verify required attributes still work
+        assert event.attributes["session.id"] == "test-session-789"
+    
+    def test_session_start_event_create_without_new_attributes(self):
+        """Test SessionStartEvent.create() without any new attributes (backward compatibility)."""
+        event = SessionStartEvent.create(
+            trace_id="test-trace-123",
+            span_id="test-span-456",
+            agent_id="test-agent",
+            session_id="test-session-789"
+        )
+        
+        # Verify new attributes are not present
+        assert "llm.vendor" not in event.attributes
+        assert "llm.model" not in event.attributes
+        assert "tools" not in event.attributes
+        assert "prompt" not in event.attributes
+        
+        # Verify basic functionality still works
+        assert event.attributes["session.id"] == "test-session-789"
+
+
+class TestAnthropicSessionStartAttributes:
+    """Test suite for Anthropic provider session start event attributes."""
+    
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.provider = AnthropicProvider()
+    
+    def test_extract_tools_for_session_with_tools(self):
+        """Test extracting tools from request body."""
+        body = {
+            "model": "claude-3-haiku-20240307",
+            "tools": [
+                {
+                    "name": "add",
+                    "description": "Add two numbers",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "a": {"type": "number"},
+                            "b": {"type": "number"}
+                        }
+                    }
+                },
+                {
+                    "name": "multiply", 
+                    "description": "Multiply two numbers",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "a": {"type": "number"},
+                            "b": {"type": "number"}
+                        }
+                    }
+                }
+            ],
+            "messages": [{"role": "user", "content": "Calculate 2+2"}]
+        }
+        
+        result = self.provider._extract_tools_for_session(body)
+        
+        assert result is not None
+        assert len(result) == 2
+        assert result[0]["name"] == "add"
+        assert result[1]["name"] == "multiply"
+    
+    def test_extract_tools_for_session_without_tools(self):
+        """Test extracting tools when no tools are present."""
+        body = {
+            "model": "claude-3-haiku-20240307",
+            "messages": [{"role": "user", "content": "Hello!"}]
+        }
+        
+        result = self.provider._extract_tools_for_session(body)
+        assert result is None
+    
+    def test_extract_tools_for_session_empty_tools(self):
+        """Test extracting tools when tools array is empty."""
+        body = {
+            "model": "claude-3-haiku-20240307",
+            "tools": [],
+            "messages": [{"role": "user", "content": "Hello!"}]
+        }
+        
+        result = self.provider._extract_tools_for_session(body)
+        assert result is None
+    
+    def test_extract_tools_for_session_invalid_tools(self):
+        """Test extracting tools when tools is not a list."""
+        body = {
+            "model": "claude-3-haiku-20240307",
+            "tools": "invalid",
+            "messages": [{"role": "user", "content": "Hello!"}]
+        }
+        
+        result = self.provider._extract_tools_for_session(body)
+        assert result is None
+    
+    def test_anthropic_session_start_with_all_attributes(self):
+        """Test Anthropic provider session start event with all new attributes."""
+        body = {
+            "model": "claude-3-haiku-20240307",
+            "system": "You are a helpful math assistant.",
+            "tools": [
+                {
+                    "name": "add",
+                    "description": "Add two numbers",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "a": {"type": "number"},
+                            "b": {"type": "number"}
+                        }
+                    }
+                }
+            ],
+            "messages": [{"role": "user", "content": "What is 2+2?"}]
+        }
+        
+        session_info = SessionInfo(
+            is_session_start=True,
+            model="claude-3-haiku-20240307",
+            conversation_id="test-session-123"
+        )
+        
+        events, _ = self.provider.extract_request_events(
+            body=body,
+            session_info=session_info,
+            session_id="test-session-123",
+            is_new_session=True
+        )
+        
+        # Find session start event
+        session_start_event = None
+        for event in events:
+            if hasattr(event, 'name') and event.name == "session.start":
+                session_start_event = event
+                break
+        
+        assert session_start_event is not None, "Session start event not found"
+        
+        # Verify new attributes
+        assert session_start_event.attributes["llm.vendor"] == "anthropic"
+        assert session_start_event.attributes["llm.model"] == "claude-3-haiku-20240307"
+        assert session_start_event.attributes["tools"] is not None
+        assert len(session_start_event.attributes["tools"]) == 1
+        assert session_start_event.attributes["tools"][0]["name"] == "add"
+        assert session_start_event.attributes["prompt"] == "You are a helpful math assistant."
+        
+        # Verify existing attributes still work
+        assert session_start_event.attributes["session.id"] == "test-session-123"
+        assert session_start_event.attributes["client.type"] == "gateway"
+    
+    def test_anthropic_session_start_without_system_prompt(self):
+        """Test Anthropic provider session start when no system prompt is provided."""
+        body = {
+            "model": "claude-3-haiku-20240307",
+            "tools": [
+                {
+                    "name": "add",
+                    "description": "Add two numbers"
+                }
+            ],
+            "messages": [{"role": "user", "content": "Hello!"}]
+        }
+        
+        session_info = SessionInfo(
+            is_session_start=True,
+            model="claude-3-haiku-20240307",
+            conversation_id="test-session-123"
+        )
+        
+        events, _ = self.provider.extract_request_events(
+            body=body,
+            session_info=session_info,
+            session_id="test-session-123",
+            is_new_session=True
+        )
+        
+        # Find session start event
+        session_start_event = None
+        for event in events:
+            if hasattr(event, 'name') and event.name == "session.start":
+                session_start_event = event
+                break
+        
+        assert session_start_event is not None
+        assert session_start_event.attributes["prompt"] == "default-system"
+    
+    def test_anthropic_session_start_without_tools(self):
+        """Test Anthropic provider session start when no tools are provided."""
+        body = {
+            "model": "claude-3-haiku-20240307",
+            "system": "You are a helpful assistant.",
+            "messages": [{"role": "user", "content": "Hello!"}]
+        }
+        
+        session_info = SessionInfo(
+            is_session_start=True,
+            model="claude-3-haiku-20240307",
+            conversation_id="test-session-123"
+        )
+        
+        events, _ = self.provider.extract_request_events(
+            body=body,
+            session_info=session_info,
+            session_id="test-session-123",
+            is_new_session=True
+        )
+        
+        # Find session start event
+        session_start_event = None
+        for event in events:
+            if hasattr(event, 'name') and event.name == "session.start":
+                session_start_event = event
+                break
+        
+        assert session_start_event is not None
+        assert "tools" not in session_start_event.attributes
+
+
+class TestOpenAISessionStartAttributes:
+    """Test suite for OpenAI provider session start event attributes."""
+    
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.provider = OpenAIProvider()
+    
+    def test_extract_tools_for_session_with_tools(self):
+        """Test extracting tools from OpenAI request body."""
+        body = {
+            "model": "gpt-4",
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "calculate",
+                        "description": "Perform calculations",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "expression": {"type": "string"}
+                            }
+                        }
+                    }
+                }
+            ],
+            "messages": [{"role": "user", "content": "Calculate 2+2"}]
+        }
+        
+        result = self.provider._extract_tools_for_session(body)
+        
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["type"] == "function"
+        assert result[0]["function"]["name"] == "calculate"
+    
+    def test_extract_tools_for_session_without_tools(self):
+        """Test extracting tools when no tools are present."""
+        body = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello!"}]
+        }
+        
+        result = self.provider._extract_tools_for_session(body)
+        assert result is None
+    
+    def test_openai_session_start_with_system_message(self):
+        """Test OpenAI provider session start with system message."""
+        body = {
+            "model": "gpt-4",
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "calculate",
+                        "description": "Perform calculations"
+                    }
+                }
+            ],
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello!"}
+            ]
+        }
+        
+        session_info = SessionInfo(
+            is_session_start=True,
+            model="gpt-4",
+            conversation_id="test-session-456"
+        )
+        
+        events, _ = self.provider.extract_request_events(
+            body=body,
+            session_info=session_info,
+            session_id="test-session-456",
+            is_new_session=True
+        )
+        
+        # Find session start event
+        session_start_event = None
+        for event in events:
+            if hasattr(event, 'name') and event.name == "session.start":
+                session_start_event = event
+                break
+        
+        assert session_start_event is not None
+        
+        # Verify new attributes
+        assert session_start_event.attributes["llm.vendor"] == "openai"
+        assert session_start_event.attributes["llm.model"] == "gpt-4"
+        assert session_start_event.attributes["tools"] is not None
+        assert len(session_start_event.attributes["tools"]) == 1
+        assert session_start_event.attributes["prompt"] == "You are a helpful assistant."
+    
+    def test_openai_session_start_with_instructions(self):
+        """Test OpenAI provider session start with instructions (Responses API)."""
+        body = {
+            "model": "gpt-4",
+            "instructions": "You are a helpful math tutor.",
+            "input": [
+                {"role": "user", "content": "Teach me algebra"}
+            ]
+        }
+        
+        session_info = SessionInfo(
+            is_session_start=True,
+            model="gpt-4",
+            conversation_id="test-session-789"
+        )
+        
+        events, _ = self.provider.extract_request_events(
+            body=body,
+            session_info=session_info,
+            session_id="test-session-789",
+            is_new_session=True
+        )
+        
+        # Find session start event
+        session_start_event = None
+        for event in events:
+            if hasattr(event, 'name') and event.name == "session.start":
+                session_start_event = event
+                break
+        
+        assert session_start_event is not None
+        assert session_start_event.attributes["prompt"] == "You are a helpful math tutor."
+    
+    def test_openai_session_start_without_system_or_instructions(self):
+        """Test OpenAI provider session start without system message or instructions."""
+        body = {
+            "model": "gpt-4",
+            "messages": [
+                {"role": "user", "content": "Hello!"}
+            ]
+        }
+        
+        session_info = SessionInfo(
+            is_session_start=True,
+            model="gpt-4",
+            conversation_id="test-session-999"
+        )
+        
+        events, _ = self.provider.extract_request_events(
+            body=body,
+            session_info=session_info,
+            session_id="test-session-999",
+            is_new_session=True
+        )
+        
+        # Find session start event
+        session_start_event = None
+        for event in events:
+            if hasattr(event, 'name') and event.name == "session.start":
+                session_start_event = event
+                break
+        
+        assert session_start_event is not None
+        assert session_start_event.attributes["prompt"] == "default-system"
+    
+    def test_openai_session_start_system_message_in_input(self):
+        """Test OpenAI provider extracting system message from input array (Responses API)."""
+        body = {
+            "model": "gpt-4",
+            "input": [
+                {"role": "system", "content": "You are a coding assistant."},
+                {"role": "user", "content": "Help me with Python"}
+            ]
+        }
+        
+        session_info = SessionInfo(
+            is_session_start=True,
+            model="gpt-4",
+            conversation_id="test-session-input"
+        )
+        
+        events, _ = self.provider.extract_request_events(
+            body=body,
+            session_info=session_info,
+            session_id="test-session-input",
+            is_new_session=True
+        )
+        
+        # Find session start event
+        session_start_event = None
+        for event in events:
+            if hasattr(event, 'name') and event.name == "session.start":
+                session_start_event = event
+                break
+        
+        assert session_start_event is not None
+        assert session_start_event.attributes["prompt"] == "You are a coding assistant."
+
+
+class TestSessionStartAttributesEdgeCases:
+    """Test suite for edge cases in session start event attributes."""
+    
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.anthropic_provider = AnthropicProvider()
+        self.openai_provider = OpenAIProvider()
+    
+    def test_session_start_event_with_none_values(self):
+        """Test SessionStartEvent.create() with None values for optional parameters."""
+        event = SessionStartEvent.create(
+            trace_id="test-trace-123",
+            span_id="test-span-456",
+            agent_id="test-agent",
+            session_id="test-session-789",
+            vendor=None,
+            model=None,
+            tools=None,
+            prompt=None
+        )
+        
+        # Verify None values don't create attributes
+        assert "llm.vendor" not in event.attributes
+        assert "llm.model" not in event.attributes
+        assert "tools" not in event.attributes
+        assert "prompt" not in event.attributes
+    
+    def test_session_start_event_with_empty_strings(self):
+        """Test SessionStartEvent.create() with empty strings."""
+        event = SessionStartEvent.create(
+            trace_id="test-trace-123",
+            span_id="test-span-456",
+            agent_id="test-agent",
+            session_id="test-session-789",
+            vendor="",
+            model="",
+            prompt=""
+        )
+        
+        # Empty strings should not create attributes (falsy values)
+        assert "llm.vendor" not in event.attributes
+        assert "llm.model" not in event.attributes
+        assert "prompt" not in event.attributes
+    
+    def test_session_start_event_with_empty_tools_list(self):
+        """Test SessionStartEvent.create() with empty tools list."""
+        event = SessionStartEvent.create(
+            trace_id="test-trace-123",
+            span_id="test-span-456",
+            agent_id="test-agent",
+            session_id="test-session-789",
+            tools=[]
+        )
+        
+        # Empty list should not create attribute (falsy value)
+        assert "tools" not in event.attributes
+    
+    def test_anthropic_complex_system_prompt(self):
+        """Test Anthropic provider with complex system prompt structure."""
+        body = {
+            "model": "claude-3-haiku-20240307",
+            "system": {
+                "type": "text",
+                "text": "You are a complex assistant with structured instructions."
+            },
+            "messages": [{"role": "user", "content": "Hello!"}]
+        }
+        
+        session_info = SessionInfo(
+            is_session_start=True,
+            model="claude-3-haiku-20240307",
+            conversation_id="test-complex-system"
+        )
+        
+        events, _ = self.anthropic_provider.extract_request_events(
+            body=body,
+            session_info=session_info,
+            session_id="test-complex-system",
+            is_new_session=True
+        )
+        
+        # Find session start event
+        session_start_event = None
+        for event in events:
+            if hasattr(event, 'name') and event.name == "session.start":
+                session_start_event = event
+                break
+        
+        assert session_start_event is not None
+        # Should convert complex system prompt to string
+        expected_prompt = str(body["system"])
+        assert session_start_event.attributes["prompt"] == expected_prompt
+    
+    def test_openai_complex_system_message_content(self):
+        """Test OpenAI provider with complex system message content."""
+        body = {
+            "model": "gpt-4",
+            "messages": [
+                {
+                    "role": "system", 
+                    "content": [
+                        {"type": "text", "text": "You are a helpful assistant."}
+                    ]
+                },
+                {"role": "user", "content": "Hello!"}
+            ]
+        }
+        
+        session_info = SessionInfo(
+            is_session_start=True,
+            model="gpt-4",
+            conversation_id="test-complex-content"
+        )
+        
+        events, _ = self.openai_provider.extract_request_events(
+            body=body,
+            session_info=session_info,
+            session_id="test-complex-content",
+            is_new_session=True
+        )
+        
+        # Find session start event
+        session_start_event = None
+        for event in events:
+            if hasattr(event, 'name') and event.name == "session.start":
+                session_start_event = event
+                break
+        
+        assert session_start_event is not None
+        # Should convert complex content to string
+        expected_prompt = str(body["messages"][0]["content"])
+        assert session_start_event.attributes["prompt"] == expected_prompt


### PR DESCRIPTION
## Summary
- Enhanced SessionStartEvent with additional metadata attributes: vendor, model, tools, and prompt
- Updated both OpenAI and Anthropic providers to extract and include these attributes in session start events
- Added comprehensive test coverage for the new functionality across all providers

## Changes
- **SessionStartEvent**: Added optional parameters for vendor, model, tools, and prompt attributes
- **Provider Updates**: Both OpenAI and Anthropic providers now extract tools and system prompts from request bodies
- **Event Enrichment**: Session start events now include LLM vendor, model information, available tools, and initial system prompts
- **Backward Compatibility**: All new attributes are optional, maintaining existing API compatibility

## Test Coverage
- Added comprehensive test suite with 630+ lines covering all scenarios
- Tests for both providers with various request formats
- Edge case handling for missing, empty, or malformed data
- Backward compatibility verification

🤖 Generated with [Claude Code](https://claude.ai/code)